### PR TITLE
fix: fixed broken links @ XRC20 how-to guides

### DIFF
--- a/learn/how-to-articles/how-to-create-and-deploy-an-xrc20-token-using-hardhat.md
+++ b/learn/how-to-articles/how-to-create-and-deploy-an-xrc20-token-using-hardhat.md
@@ -212,7 +212,7 @@ With this account in hand, we can head to the [Apothem Faucet](https://faucet.ap
 
 # 💵 Writing our first XRC20 Token
 
-The source code for the XRC20 Token used in this tutorial is available here: [XRC20 Contract Folder](./XRC20/contracts/XRC20.sol). But we will address all `Events`, `Methods` and `Constants` mentioned in the section [📰 About XRC20 Tokens](#-about-xrc20-tokens).
+The source code for the XRC20 Token used in this tutorial is available here: [XRC20 Contract Folder](./../../how-to/XRC20/Hardhat/XRC20/contracts/XRC20.sol). But we will address all `Events`, `Methods` and `Constants` mentioned in the section [📰 About XRC20 Tokens](#-about-xrc20-tokens).
 
 Lets start by creating the `XRC20.sol` file:
 

--- a/learn/how-to-articles/how-to-create-and-deploy-an-xrc20-token-using-truffle.md
+++ b/learn/how-to-articles/how-to-create-and-deploy-an-xrc20-token-using-truffle.md
@@ -243,7 +243,7 @@ With this account in hand, we can head to the [Apothem Faucet](https://faucet.ap
 
 # 💵 Writing our first XRC20 Token
 
-The source code for the XRC20 Token used in this tutorial is available here: [XRC20 Contract Folder](./XRC20/contracts/MyToken.sol). But we will address all `Events`, `Methods` and `Constants` mentioned in the section [📰 About XRC20 Tokens](#-about-xrc20-tokens).
+The source code for the XRC20 Token used in this tutorial is available here: [XRC20 Contract Folder](./../../how-to/XRC20/Truffle/XRC20/contracts/MyToken.sol). But we will address all `Events`, `Methods` and `Constants` mentioned in the section [📰 About XRC20 Tokens](#-about-xrc20-tokens).
 
 Lets start by creating the `XRC20.sol` file:
 


### PR DESCRIPTION
@WalterBlueu please have a look.

Since the tutorials: _How to Deploy an XRC20 on [Truffle](https://github.com/XDC-Community/docs/tree/main/how-to/XRC20/Truffle) & [Hardhat ](https://github.com/XDC-Community/docs/tree/main/how-to/XRC20/Hardhat)_ have links pointing to a relative path in the [how-to](https://github.com/XDC-Community/docs/tree/main/how-to) folder, these links broke when the tutorials were moved to the [learn/how-to-articles](https://github.com/XDC-Community/docs/tree/main/learn/how-to-articles) folder.

This PR fix these links.