### PR TITLE
Fix fail2ban jail config

### DIFF
--- a/run-a-node/masternode/securing-your-xdc-masternode.md
+++ b/run-a-node/masternode/securing-your-xdc-masternode.md
@@ -345,9 +345,12 @@ enabled   = true
 filter    = sshd
 port      = ssh
 banaction = iptables-multiport
-findtime  = 86400 # 86400 seconds = 1 day
-bantime   = -1 # -1 = ban forever
-maxretry  = 3 # 3 attempts in 1 day = ban
+findtime  = 86400
+# 86400 seconds = 1 day
+bantime   = -1
+# -1 = ban forever
+maxretry  = 3
+# 3 attempts in 1 day = ban
 logpath = %(sshd_log)s
 backend = %(sshd_backend)s
 ```


### PR DESCRIPTION
Having comments after maxretry in fail2ban jail config makes applicaiton fail. Comments moved to separate line for all items added to fail2ban jail config file. Note: if the # symbol causes the text to inappropriately appear as heading text in Gitbook, then the # of each comment will also need to be preceded by \